### PR TITLE
Update link to 'Am I Ready' page

### DIFF
--- a/src/components/DPASurvey.js
+++ b/src/components/DPASurvey.js
@@ -272,7 +272,7 @@ export default class DPASurvey extends HTMLElement {
         this.appContent.innerHTML = `
         <div class="row">
           <p><strong>Unfortunately, you have not completed all the requirements to apply.</strong></p>
-          <p>Please visit our <a href="https://training.detroitmi.gov/departments/housing-and-revitalization-department/detroit-down-payment-assistance-program/am-i-ready">"Am I Ready?</a> page to complete all the pre-requisites.</p>
+          <p>Please visit our <a href="/departments/housing-and-revitalization-department/detroit-down-payment-assistance-program/am-i-ready">"Am I Ready?</a> page to complete all the pre-requisites.</p>
         </div>
         <div class="d-flex">
           <div class="ms-auto">


### PR DESCRIPTION
# Closes #6 

- Removes the domain from the 'am I ready' link so that whichever environment uses the app will route to the correct URL (with current domain)

## Testing

Click on link at end of survey on local environment to confirm it routes to localhost:3000